### PR TITLE
Model golf class entities

### DIFF
--- a/src/main/java/com/t1tanic/golfclass/domain/Enrollment.java
+++ b/src/main/java/com/t1tanic/golfclass/domain/Enrollment.java
@@ -1,0 +1,33 @@
+package com.t1tanic.golfclass.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "enrollments", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"student_id", "golf_class_id"})
+})
+@Getter
+@Setter
+@NoArgsConstructor
+public class Enrollment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "student_id")
+    private Student student;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "golf_class_id")
+    private GolfClass golfClass;
+
+    private LocalDateTime enrolledAt = LocalDateTime.now();
+}
+

--- a/src/main/java/com/t1tanic/golfclass/domain/GolfClass.java
+++ b/src/main/java/com/t1tanic/golfclass/domain/GolfClass.java
@@ -1,0 +1,41 @@
+package com.t1tanic.golfclass.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "golf_classes")
+@Getter
+@Setter
+@NoArgsConstructor
+public class GolfClass {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    private String description;
+
+    private LocalDateTime startTime;
+
+    private LocalDateTime endTime;
+
+    private String location;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "instructor_id")
+    private Instructor instructor;
+
+    @OneToMany(mappedBy = "golfClass", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Enrollment> enrollments = new HashSet<>();
+}
+

--- a/src/main/java/com/t1tanic/golfclass/domain/Instructor.java
+++ b/src/main/java/com/t1tanic/golfclass/domain/Instructor.java
@@ -1,0 +1,31 @@
+package com.t1tanic.golfclass.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "instructors")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Instructor {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String firstName;
+
+    @Column(nullable = false)
+    private String lastName;
+
+    @OneToMany(mappedBy = "instructor")
+    private Set<GolfClass> classes = new HashSet<>();
+}
+

--- a/src/main/java/com/t1tanic/golfclass/domain/Student.java
+++ b/src/main/java/com/t1tanic/golfclass/domain/Student.java
@@ -1,0 +1,34 @@
+package com.t1tanic.golfclass.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "students")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Student {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String firstName;
+
+    @Column(nullable = false)
+    private String lastName;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @OneToMany(mappedBy = "student", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Enrollment> enrollments = new HashSet<>();
+}
+

--- a/src/test/java/com/t1tanic/golfclass/domain/EnrollmentJpaTest.java
+++ b/src/test/java/com/t1tanic/golfclass/domain/EnrollmentJpaTest.java
@@ -1,0 +1,52 @@
+package com.t1tanic.golfclass.domain;
+
+import com.t1tanic.golfclass.TestcontainersConfiguration;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(TestcontainersConfiguration.class)
+class EnrollmentJpaTest {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    void persistsEnrollmentGraph() {
+        Instructor instructor = new Instructor();
+        instructor.setFirstName("John");
+        instructor.setLastName("Doe");
+        entityManager.persist(instructor);
+
+        GolfClass golfClass = new GolfClass();
+        golfClass.setTitle("Short Game Basics");
+        golfClass.setInstructor(instructor);
+        entityManager.persist(golfClass);
+
+        Student student = new Student();
+        student.setFirstName("Jane");
+        student.setLastName("Smith");
+        student.setEmail("jane@example.com");
+        entityManager.persist(student);
+
+        Enrollment enrollment = new Enrollment();
+        enrollment.setStudent(student);
+        enrollment.setGolfClass(golfClass);
+        enrollment.setEnrolledAt(LocalDateTime.now());
+        entityManager.persist(enrollment);
+        entityManager.flush();
+        entityManager.clear();
+
+        Enrollment found = entityManager.find(Enrollment.class, enrollment.getId());
+        assertThat(found.getStudent().getEmail()).isEqualTo("jane@example.com");
+        assertThat(found.getGolfClass().getInstructor().getFirstName()).isEqualTo("John");
+    }
+}
+

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+spring.jpa.hibernate.ddl-auto=create-drop


### PR DESCRIPTION
## Summary
- add JPA entities for students, instructors, classes, and enrollments
- cover basic persistence with a JPA test using MySQL Testcontainers
- configure test schema generation via `spring.jpa.hibernate.ddl-auto`

## Testing
- `gradle test` *(fails: Plugin [id: 'org.springframework.boot', version: '3.5.5'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b605cc592c83239ebb091bd233f629