### PR TITLE
Model golf class entities

### DIFF
--- a/src/main/java/com/t1tanic/golfclass/domain/Enrollment.java
+++ b/src/main/java/com/t1tanic/golfclass/domain/Enrollment.java
@@ -1,0 +1,33 @@
+package com.t1tanic.golfclass.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "enrollments", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"student_id", "golf_class_id"})
+})
+@Getter
+@Setter
+@NoArgsConstructor
+public class Enrollment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "student_id")
+    private Student student;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "golf_class_id")
+    private GolfClass golfClass;
+
+    private LocalDateTime enrolledAt = LocalDateTime.now();
+}
+

--- a/src/main/java/com/t1tanic/golfclass/domain/GolfClass.java
+++ b/src/main/java/com/t1tanic/golfclass/domain/GolfClass.java
@@ -1,0 +1,41 @@
+package com.t1tanic.golfclass.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "golf_classes")
+@Getter
+@Setter
+@NoArgsConstructor
+public class GolfClass {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    private String description;
+
+    private LocalDateTime startTime;
+
+    private LocalDateTime endTime;
+
+    private String location;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "instructor_id")
+    private Instructor instructor;
+
+    @OneToMany(mappedBy = "golfClass", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Enrollment> enrollments = new HashSet<>();
+}
+

--- a/src/main/java/com/t1tanic/golfclass/domain/Instructor.java
+++ b/src/main/java/com/t1tanic/golfclass/domain/Instructor.java
@@ -1,0 +1,31 @@
+package com.t1tanic.golfclass.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "instructors")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Instructor {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String firstName;
+
+    @Column(nullable = false)
+    private String lastName;
+
+    @OneToMany(mappedBy = "instructor")
+    private Set<GolfClass> classes = new HashSet<>();
+}
+

--- a/src/main/java/com/t1tanic/golfclass/domain/Student.java
+++ b/src/main/java/com/t1tanic/golfclass/domain/Student.java
@@ -1,0 +1,34 @@
+package com.t1tanic.golfclass.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "students")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Student {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String firstName;
+
+    @Column(nullable = false)
+    private String lastName;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @OneToMany(mappedBy = "student", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Enrollment> enrollments = new HashSet<>();
+}
+

--- a/src/main/java/com/t1tanic/golfclass/repository/EnrollmentRepository.java
+++ b/src/main/java/com/t1tanic/golfclass/repository/EnrollmentRepository.java
@@ -1,0 +1,10 @@
+package com.t1tanic.golfclass.repository;
+
+import com.t1tanic.golfclass.domain.Enrollment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
+}
+

--- a/src/main/java/com/t1tanic/golfclass/repository/GolfClassRepository.java
+++ b/src/main/java/com/t1tanic/golfclass/repository/GolfClassRepository.java
@@ -1,0 +1,10 @@
+package com.t1tanic.golfclass.repository;
+
+import com.t1tanic.golfclass.domain.GolfClass;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GolfClassRepository extends JpaRepository<GolfClass, Long> {
+}
+

--- a/src/main/java/com/t1tanic/golfclass/repository/InstructorRepository.java
+++ b/src/main/java/com/t1tanic/golfclass/repository/InstructorRepository.java
@@ -1,0 +1,10 @@
+package com.t1tanic.golfclass.repository;
+
+import com.t1tanic.golfclass.domain.Instructor;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface InstructorRepository extends JpaRepository<Instructor, Long> {
+}
+

--- a/src/main/java/com/t1tanic/golfclass/repository/StudentRepository.java
+++ b/src/main/java/com/t1tanic/golfclass/repository/StudentRepository.java
@@ -1,0 +1,10 @@
+package com.t1tanic.golfclass.repository;
+
+import com.t1tanic.golfclass.domain.Student;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StudentRepository extends JpaRepository<Student, Long> {
+}
+

--- a/src/main/java/com/t1tanic/golfclass/service/EnrollmentService.java
+++ b/src/main/java/com/t1tanic/golfclass/service/EnrollmentService.java
@@ -1,0 +1,15 @@
+package com.t1tanic.golfclass.service;
+
+import com.t1tanic.golfclass.domain.Enrollment;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface EnrollmentService {
+    Enrollment create(Enrollment enrollment);
+    List<Enrollment> findAll();
+    Optional<Enrollment> findById(Long id);
+    Enrollment update(Enrollment enrollment);
+    void deleteById(Long id);
+}
+

--- a/src/main/java/com/t1tanic/golfclass/service/GolfClassService.java
+++ b/src/main/java/com/t1tanic/golfclass/service/GolfClassService.java
@@ -1,0 +1,15 @@
+package com.t1tanic.golfclass.service;
+
+import com.t1tanic.golfclass.domain.GolfClass;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface GolfClassService {
+    GolfClass create(GolfClass golfClass);
+    List<GolfClass> findAll();
+    Optional<GolfClass> findById(Long id);
+    GolfClass update(GolfClass golfClass);
+    void deleteById(Long id);
+}
+

--- a/src/main/java/com/t1tanic/golfclass/service/InstructorService.java
+++ b/src/main/java/com/t1tanic/golfclass/service/InstructorService.java
@@ -1,0 +1,15 @@
+package com.t1tanic.golfclass.service;
+
+import com.t1tanic.golfclass.domain.Instructor;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface InstructorService {
+    Instructor create(Instructor instructor);
+    List<Instructor> findAll();
+    Optional<Instructor> findById(Long id);
+    Instructor update(Instructor instructor);
+    void deleteById(Long id);
+}
+

--- a/src/main/java/com/t1tanic/golfclass/service/StudentService.java
+++ b/src/main/java/com/t1tanic/golfclass/service/StudentService.java
@@ -1,0 +1,15 @@
+package com.t1tanic.golfclass.service;
+
+import com.t1tanic.golfclass.domain.Student;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface StudentService {
+    Student create(Student student);
+    List<Student> findAll();
+    Optional<Student> findById(Long id);
+    Student update(Student student);
+    void deleteById(Long id);
+}
+

--- a/src/main/java/com/t1tanic/golfclass/service/impl/EnrollmentServiceImpl.java
+++ b/src/main/java/com/t1tanic/golfclass/service/impl/EnrollmentServiceImpl.java
@@ -1,0 +1,43 @@
+package com.t1tanic.golfclass.service.impl;
+
+import com.t1tanic.golfclass.domain.Enrollment;
+import com.t1tanic.golfclass.repository.EnrollmentRepository;
+import com.t1tanic.golfclass.service.EnrollmentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class EnrollmentServiceImpl implements EnrollmentService {
+
+    private final EnrollmentRepository enrollmentRepository;
+
+    @Override
+    public Enrollment create(Enrollment enrollment) {
+        return enrollmentRepository.save(enrollment);
+    }
+
+    @Override
+    public List<Enrollment> findAll() {
+        return enrollmentRepository.findAll();
+    }
+
+    @Override
+    public Optional<Enrollment> findById(Long id) {
+        return enrollmentRepository.findById(id);
+    }
+
+    @Override
+    public Enrollment update(Enrollment enrollment) {
+        return enrollmentRepository.save(enrollment);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        enrollmentRepository.deleteById(id);
+    }
+}
+

--- a/src/main/java/com/t1tanic/golfclass/service/impl/GolfClassServiceImpl.java
+++ b/src/main/java/com/t1tanic/golfclass/service/impl/GolfClassServiceImpl.java
@@ -1,0 +1,43 @@
+package com.t1tanic.golfclass.service.impl;
+
+import com.t1tanic.golfclass.domain.GolfClass;
+import com.t1tanic.golfclass.repository.GolfClassRepository;
+import com.t1tanic.golfclass.service.GolfClassService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class GolfClassServiceImpl implements GolfClassService {
+
+    private final GolfClassRepository golfClassRepository;
+
+    @Override
+    public GolfClass create(GolfClass golfClass) {
+        return golfClassRepository.save(golfClass);
+    }
+
+    @Override
+    public List<GolfClass> findAll() {
+        return golfClassRepository.findAll();
+    }
+
+    @Override
+    public Optional<GolfClass> findById(Long id) {
+        return golfClassRepository.findById(id);
+    }
+
+    @Override
+    public GolfClass update(GolfClass golfClass) {
+        return golfClassRepository.save(golfClass);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        golfClassRepository.deleteById(id);
+    }
+}
+

--- a/src/main/java/com/t1tanic/golfclass/service/impl/InstructorServiceImpl.java
+++ b/src/main/java/com/t1tanic/golfclass/service/impl/InstructorServiceImpl.java
@@ -1,0 +1,43 @@
+package com.t1tanic.golfclass.service.impl;
+
+import com.t1tanic.golfclass.domain.Instructor;
+import com.t1tanic.golfclass.repository.InstructorRepository;
+import com.t1tanic.golfclass.service.InstructorService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class InstructorServiceImpl implements InstructorService {
+
+    private final InstructorRepository instructorRepository;
+
+    @Override
+    public Instructor create(Instructor instructor) {
+        return instructorRepository.save(instructor);
+    }
+
+    @Override
+    public List<Instructor> findAll() {
+        return instructorRepository.findAll();
+    }
+
+    @Override
+    public Optional<Instructor> findById(Long id) {
+        return instructorRepository.findById(id);
+    }
+
+    @Override
+    public Instructor update(Instructor instructor) {
+        return instructorRepository.save(instructor);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        instructorRepository.deleteById(id);
+    }
+}
+

--- a/src/main/java/com/t1tanic/golfclass/service/impl/StudentServiceImpl.java
+++ b/src/main/java/com/t1tanic/golfclass/service/impl/StudentServiceImpl.java
@@ -1,0 +1,43 @@
+package com.t1tanic.golfclass.service.impl;
+
+import com.t1tanic.golfclass.domain.Student;
+import com.t1tanic.golfclass.repository.StudentRepository;
+import com.t1tanic.golfclass.service.StudentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class StudentServiceImpl implements StudentService {
+
+    private final StudentRepository studentRepository;
+
+    @Override
+    public Student create(Student student) {
+        return studentRepository.save(student);
+    }
+
+    @Override
+    public List<Student> findAll() {
+        return studentRepository.findAll();
+    }
+
+    @Override
+    public Optional<Student> findById(Long id) {
+        return studentRepository.findById(id);
+    }
+
+    @Override
+    public Student update(Student student) {
+        return studentRepository.save(student);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        studentRepository.deleteById(id);
+    }
+}
+

--- a/src/test/java/com/t1tanic/golfclass/domain/EnrollmentJpaTest.java
+++ b/src/test/java/com/t1tanic/golfclass/domain/EnrollmentJpaTest.java
@@ -1,0 +1,52 @@
+package com.t1tanic.golfclass.domain;
+
+import com.t1tanic.golfclass.TestcontainersConfiguration;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(TestcontainersConfiguration.class)
+class EnrollmentJpaTest {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    void persistsEnrollmentGraph() {
+        Instructor instructor = new Instructor();
+        instructor.setFirstName("John");
+        instructor.setLastName("Doe");
+        entityManager.persist(instructor);
+
+        GolfClass golfClass = new GolfClass();
+        golfClass.setTitle("Short Game Basics");
+        golfClass.setInstructor(instructor);
+        entityManager.persist(golfClass);
+
+        Student student = new Student();
+        student.setFirstName("Jane");
+        student.setLastName("Smith");
+        student.setEmail("jane@example.com");
+        entityManager.persist(student);
+
+        Enrollment enrollment = new Enrollment();
+        enrollment.setStudent(student);
+        enrollment.setGolfClass(golfClass);
+        enrollment.setEnrolledAt(LocalDateTime.now());
+        entityManager.persist(enrollment);
+        entityManager.flush();
+        entityManager.clear();
+
+        Enrollment found = entityManager.find(Enrollment.class, enrollment.getId());
+        assertThat(found.getStudent().getEmail()).isEqualTo("jane@example.com");
+        assertThat(found.getGolfClass().getInstructor().getFirstName()).isEqualTo("John");
+    }
+}
+

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+spring.jpa.hibernate.ddl-auto=create-drop


### PR DESCRIPTION
## Summary
- add Spring Data JPA repositories for student, instructor, golf class, and enrollment entities
- implement service interfaces with simple CRUD operations backed by the repositories

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b605cc592c83239ebb091bd233f629